### PR TITLE
WebSocket Subprotocol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,25 +7,25 @@ all: lib
 
 .PHONY: test
 test: lint
-        ./test/cli.sh
+	./test/cli.sh
 
 .PHONY: lint
 lint: node_modules
-        tslint -p tsconfig.json -c tslint.json -t stylish --fix
+	tslint -p tsconfig.json -c tslint.json -t stylish --fix
 
 .PHONY: lib
 lib: node_modules
-        tsc -p tsconfig.json
-        sed -i "" "1s/ts-node/node/" lib/cli.js
-        rm lib/cli.d.ts
+	tsc -p tsconfig.json
+	sed -i "" "1s/ts-node/node/" lib/cli.js
+	rm lib/cli.d.ts
 
 node_modules:
-        npm install
+	npm install
 
 .PHONY: clean
 clean:
-        rm -rf lib/
+	rm -rf lib/
 
 .PHONY: distclean
 distclean: clean
-        rm -rf node_modules/
+	rm -rf node_modules/

--- a/Makefile
+++ b/Makefile
@@ -7,25 +7,25 @@ all: lib
 
 .PHONY: test
 test: lint
-	./test/cli.sh
+        ./test/cli.sh
 
 .PHONY: lint
 lint: node_modules
-	tslint -p tsconfig.json -c tslint.json -t stylish --fix
+        tslint -p tsconfig.json -c tslint.json -t stylish --fix
 
 .PHONY: lib
 lib: node_modules
-	tsc -p tsconfig.json
-	sed -i "" "1s/ts-node/node/" lib/cli.js
-	rm lib/cli.d.ts
+        tsc -p tsconfig.json
+        sed -i "" "1s/ts-node/node/" lib/cli.js
+        rm lib/cli.d.ts
 
 node_modules:
-	npm install
+        npm install
 
 .PHONY: clean
 clean:
-	rm -rf lib/
+        rm -rf lib/
 
 .PHONY: distclean
 distclean: clean
-	rm -rf node_modules/
+        rm -rf node_modules/

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Usage
 
 ```
 $ wscat -h
-usage: wscat [-h] [-v] [-l PORT] [-b] [-k] [-d] [address]
+usage: wscat [-h] [-v] [-l PORT] [-b] [-k] [-d] [-s SUBP] [address]
 
 Positional arguments:
   address
@@ -30,6 +30,8 @@ Optional arguments:
   -b, --binary          Use binary WebSockets.
   -k, --keep-open       Do not close the socket after EOF.
   -d, --deflate         Use per-message deflate.
+  -s SUBP, --subprotocol SUBP
+                        WebSocket subprotocol
 
 ```
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,13 @@ parser.addArgument(['-d', '--deflate'], {
     help: 'Use per-message deflate.',
 })
 
+parser.addArgument(['-s', '--subprotocol'], {
+    type: String,
+    metavar: 'SUBP',
+    dest: 'subProto',
+    help: 'WebSocket subprotocol',
+})
+
 parser.addArgument(['address'], {
     nargs: '?',
     type: String,
@@ -52,6 +59,7 @@ const options: any = {
     keepOpen: args.keepOpen,
     outputStream: process.stdout,
     perMessageDeflate: args.deflate,
+    protocol: args.subProto,
 }
 
 if (args.address) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,10 +40,10 @@ parser.addArgument(['-d', '--deflate'], {
 })
 
 parser.addArgument(['-s', '--subprotocol'], {
-    type: String,
-    metavar: 'SUBP',
     dest: 'subProto',
     help: 'WebSocket subprotocol',
+    metavar: 'SUBP',
+    type: String,
 })
 
 parser.addArgument(['address'], {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ interface ICLIOptions {
     deflate: boolean
     keepOpen: boolean
     listen?: number
+    subProto?: string
 }
 
 const parser = new ArgumentParser({version, addHelp: true})

--- a/src/wscat.ts
+++ b/src/wscat.ts
@@ -24,6 +24,7 @@ export interface IOptions {
     keepOpen: boolean
     outputStream: NodeJS.WritableStream
     perMessageDeflate: boolean
+    protocol: string
 }
 
 export interface IConnectOptions extends IOptions {


### PR DESCRIPTION
Hi,

Some WebSocket servers **require** specifying the subprotocol value used in the `Sec-WebSocket-Protocol` header during the handshake.

I have added a new argument (`-s, --subprotocol`) that updates the connection protocol option.

Thank you in advance!