### PR TITLE
Add rawmode option to stdin

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import * as wscat from './wscat'
 interface ICLIOptions {
     address?: string
     binary: boolean
+    useRaw: boolean
     deflate: boolean
     keepOpen: boolean
     listen?: number
@@ -27,6 +28,13 @@ parser.addArgument(['-b', '--binary'], {
     action: 'storeTrue',
     defaultValue: false,
     help: 'Use binary WebSockets.',
+})
+
+parser.addArgument(['-r', '--raw'], {
+    action: 'storeTrue',
+    defaultValue: false,
+    dest: 'useRaw',
+    help: 'Use rawmode stdin.',
 })
 
 parser.addArgument(['-H', '--header'], {
@@ -88,6 +96,7 @@ const options: any = {
     perMessageDeflate: args.deflate,
     protocol: args.subProto,
     rejectUnauthorized: !args.noCheck,
+    useRaw: args.useRaw,
 }
 
 if (args.address) {

--- a/src/wscat.ts
+++ b/src/wscat.ts
@@ -21,6 +21,7 @@ import {WebSocketStream} from './stream'
 export interface IOptions {
     binary: boolean
     inputStream: NodeJS.ReadableStream
+    useRaw: boolean
     keepOpen: boolean
     outputStream: NodeJS.WritableStream
     perMessageDeflate: boolean
@@ -47,9 +48,18 @@ function setup(options: IOptions, socket: WebSocket) {
         options.inputStream.pipe(stream)
     }
 
+    if (options.inputStream === process.stdin && process.stdin.isTTY) {
+        if (options.useRaw) {
+            (process.stdin as any).setRawMode(true)
+        }
+    }
+
     stream.on('close', () => {
         if (options.inputStream === process.stdin && process.stdin.isTTY) {
-           process.exit()
+            if (options.useRaw) {
+                (process.stdin as any).setRawMode(false)
+            }
+            process.exit()
         }
     })
     stream.on('finish', () => {


### PR DESCRIPTION
It would be nice if there was an option to set rawmode on stdin so that wscat can be used to talk directly to things like pty servers.  This way the host console sends down raw keypresses instead of buffered lines.